### PR TITLE
Add MIDI driver option

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ Force a specific driver:
 audio_driver = pipewire
 ```
 
+### MIDI Driver Selection
+
+Currently only the ALSA sequencer backend is implemented. The default is
+`alsa_seq`. Future versions may support raw ALSA devices.
+
+```ini
+midi_driver = alsa_seq
+```
+
 ### Audio Effects
 
 midisynthd exposes simple controls for its built‑in effects.

--- a/config/midisynthd.conf
+++ b/config/midisynthd.conf
@@ -3,4 +3,5 @@ soundfont=/usr/share/sounds/sf2/FluidR3_GM.sf2
 gain=0.5
 polyphony=256
 audio_driver=auto
+midi_driver=alsa_seq
 midi_autoconnect=yes

--- a/config/midisynthd.conf.example
+++ b/config/midisynthd.conf.example
@@ -3,4 +3,5 @@
 #gain=1.0
 #polyphony=512
 #audio_driver=pipewire
+#midi_driver=alsa_seq
 #midi_autoconnect=yes

--- a/src/config.c
+++ b/src/config.c
@@ -157,6 +157,7 @@ void config_init_defaults(midisynthd_config_t *config) {
     
     /* Audio settings */
     config->audio_driver = AUDIO_DRIVER_AUTO;
+    config->midi_driver = MIDI_DRIVER_ALSA_SEQ;
     config->sample_rate = CONFIG_DEFAULT_SAMPLE_RATE;
     config->buffer_size = CONFIG_DEFAULT_BUFFER_SIZE;
     config->audio_periods = CONFIG_DEFAULT_AUDIO_PERIODS;
@@ -238,6 +239,9 @@ static void parse_config_line(midisynthd_config_t *config, const char *line) {
     }
     else if (strcasecmp(trimmed_key, "audio_driver") == 0) {
         config->audio_driver = parse_audio_driver(trimmed_value);
+    }
+    else if (strcasecmp(trimmed_key, "midi_driver") == 0) {
+        config->midi_driver = config_parse_midi_driver(trimmed_value);
     }
     else if (strcasecmp(trimmed_key, "sample_rate") == 0) {
         config->sample_rate = parse_int(trimmed_value, 8000, 192000, CONFIG_DEFAULT_SAMPLE_RATE);
@@ -508,6 +512,7 @@ void config_print(const midisynthd_config_t *config) {
     printf("  Gain:               %.2f\n", config->gain);
     
     printf("\nMIDI:\n");
+    printf("  Driver:             %s\n", config_midi_driver_to_string(config->midi_driver));
     printf("  Client Name:        %s\n", config->client_name);
     printf("  Auto-connect:       %s\n", config->midi_autoconnect ? "yes" : "no");
     
@@ -564,6 +569,7 @@ int config_save(const midisynthd_config_t *config, const char *filename) {
     if (!f) return -1;
     fprintf(f, "log_level=%s\n", config_log_level_to_string(config->log_level));
     fprintf(f, "audio_driver=%s\n", config_audio_driver_to_string(config->audio_driver));
+    fprintf(f, "midi_driver=%s\n", config_midi_driver_to_string(config->midi_driver));
     fprintf(f, "sample_rate=%d\n", config->sample_rate);
     fprintf(f, "buffer_size=%d\n", config->buffer_size);
     fprintf(f, "audio_periods=%d\n", config->audio_periods);

--- a/src/config.h
+++ b/src/config.h
@@ -134,6 +134,7 @@ typedef struct {
 typedef struct midisynthd_config_t {
     log_level_t log_level;
     audio_driver_t audio_driver;
+    midi_driver_t midi_driver;
     int sample_rate;
     int buffer_size;
     int audio_periods;

--- a/src/main.c
+++ b/src/main.c
@@ -371,8 +371,19 @@ static int initialize_modules(void) {
         return -1;
     }
     
-    syslog(LOG_INFO, "Initializing ALSA MIDI input system");
-    g_midi = midi_alsa_init(&g_config, g_synth);
+    syslog(LOG_INFO, "Initializing %s MIDI input system",
+           config_midi_driver_to_string(g_config.midi_driver));
+    switch (g_config.midi_driver) {
+        case MIDI_DRIVER_ALSA_SEQ:
+            g_midi = midi_alsa_init(&g_config, g_synth);
+            break;
+        case MIDI_DRIVER_ALSA_RAW:
+            syslog(LOG_ERR, "MIDI driver 'alsa_raw' not implemented");
+            return -1;
+        default:
+            syslog(LOG_ERR, "Unknown MIDI driver %d", g_config.midi_driver);
+            return -1;
+    }
     if (!g_midi) {
         syslog(LOG_ERR, "Failed to initialize MIDI input system");
         return -1;

--- a/tests/stubs.c
+++ b/tests/stubs.c
@@ -17,6 +17,7 @@ void config_init_defaults(midisynthd_config_t *cfg) {
     cfg->audio_periods = CONFIG_DEFAULT_AUDIO_PERIODS;
     cfg->polyphony = CONFIG_DEFAULT_POLYPHONY;
     cfg->audio_driver = AUDIO_DRIVER_AUTO;
+    cfg->midi_driver = MIDI_DRIVER_ALSA_SEQ;
     cfg->log_level = LOG_LEVEL_INFO;
     cfg->midi_autoconnect = true;
     cfg->chorus_enabled = true;


### PR DESCRIPTION
## Summary
- support selecting a MIDI backend via `midi_driver` config option
- default to ALSA sequencer in config
- show the MIDI driver when printing and saving configuration
- switch on `midi_driver` in main to choose the backend
- document the new option and update sample configs

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684e0c37c66c8330b400eaf025f5de8c