### PR TITLE
Remove dead type definitions

### DIFF
--- a/src/audio.h
+++ b/src/audio.h
@@ -38,60 +38,6 @@ typedef struct audio_s audio_t;
 
 /* Audio driver type comes from config.h */
 
-/**
- * Audio buffer size presets for different use cases
- */
-typedef enum {
-    AUDIO_BUFFER_SIZE_ULTRA_LOW = 32,    /* Ultra-low latency (gaming, live performance) */
-    AUDIO_BUFFER_SIZE_LOW = 64,          /* Low latency (interactive use) */
-    AUDIO_BUFFER_SIZE_NORMAL = 128,      /* Normal latency (general use) */
-    AUDIO_BUFFER_SIZE_HIGH = 256,        /* High latency (less CPU usage) */
-    AUDIO_BUFFER_SIZE_ULTRA_HIGH = 512   /* Ultra-high latency (very low CPU) */
-} audio_buffer_size_t;
-
-/**
- * Audio sample rate constants
- */
-typedef enum {
-    AUDIO_SAMPLE_RATE_22050 = 22050,
-    AUDIO_SAMPLE_RATE_44100 = 44100,
-    AUDIO_SAMPLE_RATE_48000 = 48000,    /* Recommended default */
-    AUDIO_SAMPLE_RATE_88200 = 88200,
-    AUDIO_SAMPLE_RATE_96000 = 96000
-} audio_sample_rate_t;
-
-/**
- * Audio format constants
- */
-typedef enum {
-    AUDIO_FORMAT_16BIT = 16,
-    AUDIO_FORMAT_24BIT = 24,
-    AUDIO_FORMAT_32BIT = 32              /* Float format */
-} audio_format_t;
-
-/**
- * Audio driver capabilities and status
- */
-typedef struct {
-    bool available;                      /* Driver is available on system */
-    bool active;                         /* Driver is currently running */
-    bool realtime_capable;               /* Supports real-time operation */
-    const char *description;             /* Human-readable description */
-    const char *version;                 /* Driver version if available */
-} audio_driver_info_t;
-
-/**
- * Audio system runtime statistics
- */
-typedef struct {
-    uint32_t sample_rate;                /* Current sample rate */
-    uint16_t buffer_size;                /* Current buffer size in frames */
-    uint8_t channels;                    /* Number of audio channels */
-    uint8_t format_bits;                 /* Audio format bit depth */
-    float cpu_load;                      /* CPU load percentage (0.0-100.0) */
-    uint64_t xruns;                      /* Number of audio dropouts */
-    bool realtime_active;                /* Real-time scheduling active */
-} audio_stats_t;
 
 /**
  * Initialize audio subsystem

--- a/src/config.h
+++ b/src/config.h
@@ -88,48 +88,6 @@ typedef struct {
     float gain_offset;
 } soundfont_config_t;
 
-/* Audio configuration */
-typedef struct {
-    audio_driver_t driver;
-    char device[CONFIG_MAX_STRING_LEN];
-    int sample_rate;
-    int buffer_size;
-    int buffer_count;
-    bool realtime_priority;
-    int priority_level;
-} audio_config_t;
-
-/* MIDI configuration */
-typedef struct {
-    midi_driver_t driver;
-    char device[CONFIG_MAX_STRING_LEN];
-    bool autoconnect;
-    bool announce;
-    char client_name[CONFIG_MAX_STRING_LEN];
-    int client_id;
-} midi_config_t;
-
-/* Synthesis engine configuration */
-typedef struct {
-    int polyphony;
-    float gain;
-    bool interpolation;
-    
-    /* Chorus settings */
-    bool chorus_enabled;
-    int chorus_voices;
-    float chorus_level;
-    float chorus_speed;
-    float chorus_depth;
-    int chorus_type;
-    
-    /* Reverb settings */
-    bool reverb_enabled;
-    float reverb_level;
-    float reverb_roomsize;
-    float reverb_damping;
-    float reverb_width;
-} synth_config_t;
 
 /* Main configuration structure used by config.c */
 typedef struct midisynthd_config_t {


### PR DESCRIPTION
## Summary
- clean up `audio.h` by dropping unused enums and structs
- remove obsolete config structs from `config.h`
- verify build and tests still pass

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684f185158948330bb1b60a296eed417